### PR TITLE
Issue with comments replies 

### DIFF
--- a/src/facebook_mcp_server/server.py
+++ b/src/facebook_mcp_server/server.py
@@ -45,7 +45,7 @@ class FacebookManager:
 
     def reply_to_comment(self, post_id: str, comment_id: str, message: str) -> dict[str, Any]:
         """Replies to a comment on a specific post."""
-        url = f"{GRAPH_API_BASE_URL}/{comment_id}/replies"
+        url = f"{GRAPH_API_BASE_URL}/{comment_id}/comments"
         params = {
             "message": message,
             "access_token": PAGE_ACCESS_TOKEN,


### PR DESCRIPTION
There is no '/replies' edge on comment - 

"It is possible for comment objects to have a /comments edge, which is called comment replies. The structure is the same for these, but attention should be paid to the modifiers for these edges."

https://developers.facebook.com/docs/graph-api/reference/v22.0/object/comments