### PR TITLE
Add Docker support and push it to ghcr.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Docker Builds
+
+on:
+  push
+
+
+jobs:
+  build-ghcr:
+    if: "contains(github.event.head_commit.message, 'build')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20
+        with:
+          cosign-release: 'v2.2.4'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build-ghcr:
-    if: "contains(github.event.head_commit.message, 'build')"
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use astral/uv image with latest tag
+FROM astral/uv:latest
+
+# Set working directory
+WORKDIR /app
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONIOENCODING=utf-8
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies using uv
+RUN uv sync --frozen
+
+# Copy source code
+COPY src/ ./src/
+COPY README.md .gitignore .python-version ./
+
+# Create .env file placeholder (will be overridden by volume mount or environment variables)
+COPY src/facebook_mcp_server/.env.example .env
+
+# Set the default command to run the MCP server in stdio mode
+CMD ["uv", "run", "facebook-mcp-server"]


### PR DESCRIPTION
This pull request introduces a Docker-based workflow for building, publishing, and signing Docker images, as well as a new `Dockerfile` for containerizing the application. The main focus is on enabling automated Docker builds and deployments using GitHub Actions and modern dependency management via `uv`.

**Docker workflow automation:**

* Added a new GitHub Actions workflow `.github/workflows/docker-publish.yml` that builds, pushes, and signs Docker images to GitHub Container Registry when the commit message contains 'build'. The workflow uses Docker Buildx for multi-architecture builds, caches layers, and signs images with Cosign.

**Dockerfile and containerization:**

* Introduced a new `Dockerfile` based on the `astral/uv:latest` image, which sets up the working directory, environment variables, installs dependencies using `uv`, copies source code and configuration files, and defines the default command to run the MCP server.